### PR TITLE
Fix for error in format due to float in align

### DIFF
--- a/vcdvcd/vcdvcd.py
+++ b/vcdvcd/vcdvcd.py
@@ -113,7 +113,7 @@ class VCDVCD(object):
                                 i = 1
                             identifier_code = references_to_ids[ref]
                             size = int(self._data[identifier_code]['size'])
-                            width = max(((size / 4)), int(math.floor(math.log10(i))) + 1)
+                            width = max(((size // 4)), int(math.floor(math.log10(i))) + 1)
                             references_to_widths[ref] = width
                         print()
                         print('0 '.format(i, ), end='')


### PR DESCRIPTION
I faced an error in format function due to alignment value being a float. My guess is the error was triggered because I used python 3.8. Fix should work in any version of Python.