### PR TITLE
Added a record for the first VCD timestamp

### DIFF
--- a/vcdvcd/vcdvcd.py
+++ b/vcdvcd/vcdvcd.py
@@ -90,6 +90,7 @@ class VCDVCD(object):
         """
         self.data = {}
         self.endtime = 0
+        self.begintime = 0
         self.references_to_ids = {}
         self.signals = []
         self.timescale = {}
@@ -106,6 +107,7 @@ class VCDVCD(object):
         hier = []
         num_sigs = 0
         time = 0
+        first_time = True
         with open(vcd_path, 'r') as f:
             while True:
                 line = f.readline()
@@ -127,6 +129,9 @@ class VCDVCD(object):
                 elif line0 == '#':
                     callbacks.time(self, time, cur_sig_vals)
                     time = int(line[1:])
+                    if first_time:
+                        self.begintime = time
+                        first_time = False
                     self.endtime = time
                     self.signal_changed = False
                 elif '$enddefinitions' in line:


### PR DESCRIPTION
* Added VCDVCD class member 'begintime'
* Just like 'endtime', 'begintime' stores the first timestamp
* It is assumed that the timestamps in the VCD file are ordered as imposed
  by the Verilog standard, so no checks are made to verify the timestamp
  at the first position is indeed the smallest timestamp