### PR TITLE
Fixed a bug in parsing out-of-scope signals

### DIFF
--- a/vcdvcd/vcdvcd.py
+++ b/vcdvcd/vcdvcd.py
@@ -150,7 +150,10 @@ class VCDVCD(object):
                     identifier_code = ls[3]
                     name = ''.join(ls[4:-1])
                     path = '.'.join(hier)
-                    reference = path + '.' + name
+                    if path:
+                        reference = path + '.' + name
+                    else:
+                        reference = name
                     if (reference in signals) or all_sigs:
                         self.signals.append(reference)
                         if identifier_code not in self.data:


### PR DESCRIPTION
* When there are variables in the VCD file outside any scope, the current
  reference generation generates an empty module hierarchy, which results
  in a reference with a preceding period (e.g., ".sig1")
* I added three lines to check whether the path is empty, and if it is, the signal   name is added as reference, and "path + '.' + name" (original behavior)  otherwise