### PR TITLE
Added support for single-line simulation command

### DIFF
--- a/test.py
+++ b/test.py
@@ -20,6 +20,24 @@ $end
 0"
 '''
 
+    SINGLE_LINE_VALUE_CHANGE_VCD = '''
+$timescale 1 us $end
+$scope module X $end
+$var wire 1 ! D0 $end
+$var wire 1 " D1 $end
+$upscope $end
+$enddefinitions $end
+
+#0  0! 1"
+#503236  1!
+#649868  0"
+#753652  1"
+#880824  0"
+#984044  1"
+#1110740  0"
+#1214876
+'''
+
     def test_data(self):
         vcd = VCDVCD('counter_tb.vcd')
         signal = vcd['counter_tb.out[1:0]']
@@ -139,6 +157,24 @@ $end
         vcd = VCDVCD(vcd_string=self.SMALL_CLOCK_VCD)
         with self.assertRaises(KeyError):
             vcd['non_existent_signal']
+
+    def test_single_line_value_change(self):
+        """
+        Tests correct parsing when time stamp and value change are on the same
+        line, separated by white space
+        """
+        vcd = VCDVCD(vcd_string=self.SINGLE_LINE_VALUE_CHANGE_VCD)
+        D0 = vcd['X.D0']
+        D1 = vcd['X.D1']
+        self.assertEqual(D0[0], '0')
+        self.assertEqual(D0[503236], '1')
+
+        self.assertEqual(D1[0], '1')
+        self.assertEqual(D1[649868], '0')
+        self.assertEqual(D1[753652], '1')
+        self.assertEqual(D1[880824], '0')
+        self.assertEqual(D1[984044], '1')
+        self.assertEqual(D1[1110740], '0')
 
 if __name__ == '__main__':
     unittest.main()

--- a/vcdvcd/vcdvcd.py
+++ b/vcdvcd/vcdvcd.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import math
 import re
+from decimal import Decimal as D
 
 class VCDVCD(object):
 
@@ -154,20 +155,24 @@ class VCDVCD(object):
                             if '$end'  in line:
                                 break
                     timescale = ' '.join(line.split()[1:-1])
-                    number    = re.findall(r"\d+|$", timescale)[0]
+                    magnitude = D(re.findall(r"\d+|$", timescale)[0])
+                    if magnitude not in [1, 10, 100]:
+                        print("Error: Magnitude of timescale must be one of 1, 10, or 100. "\
+                            + "Current magnitude is: {}".format(magnitude))
+                        exit(-1)
                     unit      = re.findall(r"s|ms|us|ns|ps|fs|$", timescale)[0]
                     factor = {
-                        "s":  1e0,
-                        "ms": 1e-3,
-                        "us": 1e-6,
-                        "ns": 1e-9,
-                        "ps": 1e-12,
-                        "fs": 1e-15,
+                        "s":  '1e0',
+                        "ms": '1e-3',
+                        "us": '1e-6',
+                        "ns": '1e-9',
+                        "ps": '1e-12',
+                        "fs": '1e-15',
                     }[unit]
-                    self._timescale["timescale"] = int(number) * factor
-                    self._timescale["number"] = int(number)
+                    self._timescale["timescale"] = magnitude * D(factor)
+                    self._timescale["magnitude"] = magnitude
                     self._timescale["unit"]   = unit
-                    self._timescale["factor"] = factor
+                    self._timescale["factor"] = D(factor)
 
     def get_data(self):
         """

--- a/vcdvcd/vcdvcd.py
+++ b/vcdvcd/vcdvcd.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 
 import math
 import re
-from decimal import Decimal as D
+from decimal import Decimal
 
 class VCDVCD(object):
 
@@ -155,7 +155,7 @@ class VCDVCD(object):
                             if '$end'  in line:
                                 break
                     timescale = ' '.join(line.split()[1:-1])
-                    magnitude = D(re.findall(r"\d+|$", timescale)[0])
+                    magnitude = Decimal(re.findall(r"\d+|$", timescale)[0])
                     if magnitude not in [1, 10, 100]:
                         print("Error: Magnitude of timescale must be one of 1, 10, or 100. "\
                             + "Current magnitude is: {}".format(magnitude))
@@ -169,10 +169,10 @@ class VCDVCD(object):
                         "ps": '1e-12',
                         "fs": '1e-15',
                     }[unit]
-                    self._timescale["timescale"] = magnitude * D(factor)
+                    self._timescale["timescale"] = magnitude * Decimal(factor)
                     self._timescale["magnitude"] = magnitude
                     self._timescale["unit"]   = unit
-                    self._timescale["factor"] = D(factor)
+                    self._timescale["factor"] = Decimal(factor)
 
     def get_data(self):
         """


### PR DESCRIPTION
* PulseView generates VCD files with value changes on the same line as the time stamp, separated by white-space
* Not sure if standard-compliant, but added support for it as GTKWave also supports it
* Added a test to the testbench