### PR TITLE
Add robustness regarding VCD syntax

### DIFF
--- a/test.py
+++ b/test.py
@@ -174,5 +174,24 @@ $enddefinitions $end
         self.assertEqual(D1[30], '1')
         self.assertEqual(D1[35], '0')
 
+# Test deviations to the VCD syntax
+
+    MISSING_IDENTIFIER = '''$var wire 2 ! out [1:0] $end
+$enddefinitions $end
+#0
+$dumpvars
+bx !
+$end
+#1
+b1
+'''
+
+    def test_missing_identifier(self):
+        """
+        Tests correct parsing when time stamp and value change are on the same
+        line, separated by white space
+        """
+        vcd = VCDVCD(vcd_string=self.MISSING_IDENTIFIER)
+
 if __name__ == '__main__':
     unittest.main()

--- a/vcdvcd/vcdvcd.py
+++ b/vcdvcd/vcdvcd.py
@@ -143,7 +143,11 @@ class VCDVCD(object):
                 time, value, identifier_code, cur_sig_vals, callbacks)
 
         def handle_vector_value_change(line):
-            value, identifier_code = line[1:].split()
+            fields = line[1:].split()
+            if len(fields) < 2:
+                print(f"Warning: Ignored missing identifier in line: `{line}`.")
+                return
+            value, identifier_code = fields
             self._add_value_identifier_code(
                 time, value, identifier_code, cur_sig_vals, callbacks)
 


### PR DESCRIPTION
Hi,

We noticed that some tools may produce malformed VCD files.
This patch adds robustness so that vcdvcd works with more tools.

Kind regards,
Flavien