### PR TITLE
vcdcat: don't select sub-string matches when using --exact

### DIFF
--- a/vcdcat
+++ b/vcdcat
@@ -105,7 +105,7 @@ Now get the values for signals:
                     if (
                         (args.regexp and r.search(a)) or
                         (args.exact and s == a) or
-                        (s in a)
+                        (not args.exact and s in a)
                     ):
                         selected_signals.append(a)
         if args.list:


### PR DESCRIPTION
When using `--exact` matching for a signal that is a common prefix of other signals the `in` check would match other signals:

Before:

```
$ ./vcdvcd/vcdcat -l -x bars-fix.vcd application.tft
application.tft_go
application.tft_go_set
application.tft
```

After:

```
$ ./vcdvcd/vcdcat -l -x bars-fix.vcd application.tft
application.tft
```