### PR TITLE
vcd.timescale: don't restrict it from representing odd timescales

### DIFF
--- a/test.py
+++ b/test.py
@@ -36,6 +36,28 @@ $enddefinitions $end
 #40
 '''
 
+    EXTRA_METADATA_VCD = '''$date
+	Created November 08, 2023
+$end
+$version
+	Dumped by version v1.1
+$end
+$timescale 6666ps $end
+$scope module X $end
+$var wire 1 ! D0 $end
+$var wire 1 " D1 $end
+$enddefinitions $end
+
+$dumpvars
+x!
+x"
+$end
+
+#10  1!
+#15  0"
+#20  1"
+'''
+
     def test_data(self):
         vcd = VCDVCD('counter_tb.vcd')
         signal = vcd['counter_tb.out[1:0]']
@@ -173,6 +195,29 @@ $enddefinitions $end
         self.assertEqual(D1[25], '0')
         self.assertEqual(D1[30], '1')
         self.assertEqual(D1[35], '0')
+
+    def test_simple_timescale_values(self):
+        from decimal import Decimal
+
+        # simple timescale
+        vcd = VCDVCD(vcd_string=self.SINGLE_LINE_VALUE_CHANGE_VCD)
+        self.assertEqual(vcd.timescale["timescale"], Decimal('0.000001'))
+        self.assertEqual(vcd.timescale["magnitude"], 1)
+        self.assertEqual(vcd.timescale["unit"], "us")
+        self.assertEqual(vcd.timescale["factor"], Decimal('0.000001'))
+
+        # No timescale
+        vcd = VCDVCD(vcd_string=self.SMALL_CLOCK_VCD)
+        self.assertEqual(len(vcd.timescale), 0)
+
+        # Odd timescale based on 150MHz
+        vcd = VCDVCD(vcd_string=self.EXTRA_METADATA_VCD)
+        self.assertEqual(vcd.timescale["timescale"], Decimal('6.666E-9'))
+        self.assertEqual(vcd.timescale["magnitude"], 6666)
+        self.assertEqual(vcd.timescale["unit"], "ps")
+        self.assertEqual(vcd.timescale["factor"], Decimal('1E-12'))
+        # but its badly rounded
+        self.assertAlmostEqual(Decimal('6.666E-9') * Decimal('150E6'), 1, places=3)
 
 if __name__ == '__main__':
     unittest.main()

--- a/vcdvcd/vcdvcd.py
+++ b/vcdvcd/vcdvcd.py
@@ -228,10 +228,6 @@ class VCDVCD(object):
                             break
                 timescale = ' '.join(line.split()[1:-1])
                 magnitude = Decimal(re.findall(r"\d+|$", timescale)[0])
-                if magnitude not in [1, 10, 100]:
-                    print("Error: Magnitude of timescale must be one of 1, 10, or 100. "\
-                        + "Current magnitude is: {}".format(magnitude))
-                    exit(-1)
                 unit      = re.findall(r"s|ms|us|ns|ps|fs|$", timescale)[0]
                 factor = {
                     "s":  '1e0',


### PR DESCRIPTION
This is not as straight-forward as the last.  We have equipment that generates vcd traces from a 150MHz clock, and `vcdcat` can't parse it because of the odd timescale represented as 6666ps.

I feel OK suggesting removing that guard for a few reasons:

1. There's no code (left?) that actually uses the value of the `timescale` in such a way that odd numbers could upset some maths
2. The `timescale` vcd representation seems to have the same expressive power as `Decimal()` used in the library so it doesn't look like there's any reason the values will go wrong (eg as they might with float conversions)
3. its the only `exit()` call in the library portion - ie at the very least that exit-code should be replaced with an exception to allow library users to choose a different response

My only concern is that it removes _all_ checking of the value of `magnitude` - the only downside I can think of is that if it might not properly discard the `magnitude` of `0`, or accidentally accept a failure to parse as a `0` rather than rejecting it outright.

I added some representative (proprietaryness removed) vcd to the tests to match, but realised most of the metadata isn't parsed so added it simply in case future versions want to parse the `$version`, `$date` or whatever, they'll accept what we produce.