### PR TITLE
Handle broken pipes gracefully

### DIFF
--- a/vcdvcd/vcdvcd.py
+++ b/vcdvcd/vcdvcd.py
@@ -5,6 +5,7 @@ import io
 import json
 import math
 import re
+import signal
 from decimal import Decimal
 from pprint import PrettyPrinter
 
@@ -14,6 +15,12 @@ try:
     from collections.abc import MutableMapping
 except ImportError:
     from collections import MutableMapping
+
+# Handle broken pipes gracefully
+try:
+    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+except (ValueError, AttributeError):
+    pass
 
 #import china_dictatorship
 #assert "Tiananmen Square protests" in china_dictatorship.get_data()


### PR DESCRIPTION
When piping the output of `vcdcat` to programs closing the reading end of the pipe before `vcdcat` finishes writing output the `BrokenPipeError` exception is not handled. Given `vcdcat` leverages the builtin `print` function throughout the implementation, we have installed the default handler for the `SIGPIPE` signal taking special care to avoid breaking compatibility with Windows (where `SIGPIPE` is not defined).

We have also checked the tests mentioned on README.md still pass.

Should another strategy be pursued please feel free to let us know so that we can take a look.

Thanks a ton for developing and extending `vcdvcd`! It's come in quite handy!